### PR TITLE
Removing password security validation in nestjs

### DIFF
--- a/back-ends/nest_login/src/login/dto/edit-password.dto.ts
+++ b/back-ends/nest_login/src/login/dto/edit-password.dto.ts
@@ -1,9 +1,9 @@
-import { IsString, IsStrongPassword } from "class-validator";
+import { IsString } from "class-validator";
 
 export class EditPasswordDto {
   @IsString()
   current_password: string;
 
-  @IsStrongPassword()
+  @IsString() // We do not use isStrongPassword from class-validator as it can cause conflicts with front-end validation and it isn't necessary (if a user wants to manipulate the frontend to use a weak password, so be it)
   new_password: string;
 }

--- a/back-ends/nest_login/src/login/dto/modify-new-account.dto.ts
+++ b/back-ends/nest_login/src/login/dto/modify-new-account.dto.ts
@@ -1,9 +1,9 @@
-import { IsEmail, IsStrongPassword } from "class-validator";
+import { IsEmail, IsString } from "class-validator";
 
 export class ModifyNewAccountDto {
   @IsEmail()
   new_email: string;
 
-  @IsStrongPassword()
+  @IsString()
   new_password: string;
 }

--- a/back-ends/nest_login/src/login/dto/reset-password.dto.ts
+++ b/back-ends/nest_login/src/login/dto/reset-password.dto.ts
@@ -1,9 +1,9 @@
-import { IsString, IsStrongPassword } from "class-validator";
+import { IsString } from "class-validator";
 
 export class ResetPasswordDto {
   @IsString()
   code: string;
 
-  @IsStrongPassword()
+  @IsString()
   new_password: string;
 }


### PR DESCRIPTION
Removing password security validation in nestjs (backend) as it can cause conflicts with frontends and isn't necessary (if a user wants to manipulate the frontend to use an unsafe password, so be it, it's their problem).